### PR TITLE
Add a snapcraft build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+# Krop [![Snap Status](https://build.snapcraft.io/badge/gocarlos/krop.svg)](https://build.snapcraft.io/user/gocarlos/krop)
+
 krop is a simple graphical tool to crop the pages of PDF files. It is written in Python and relies on PyQT, python-poppler-qt4 and pyPDF for its functionality. A unique feature of krop is its ability to automatically split pages into subpages to fit the limited screen size of devices such as eReaders. This is particularly useful, if your eReader does not support convenient scrolling.


### PR DESCRIPTION
Congrats on the snap of krop! Here's a badge to show the latest snap build.

Once https://github.com/canonical-websites/build.snapcraft.io/issues/825 gets fixed it'll add the missing `--devmode`. Even without that in place snap is going to guide you to use `--devmode` when you try to install with just `snap install --edge krop`.