### PR TITLE
Allow `krop` command to launch Krop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ The installation can be done using the terminal or using the software center.
 * ##### To start GUI type:
 
     ```bash
-    # Due to the nature of the snap apps:
-    # instead of krop, on has to type krop.krop-app to use the app
-    krop.krop-app
+    krop
     ```
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ confinement:        strict
 type:               app
 
 apps:
-  krop-app:
+  krop:
     command:        desktop-launch krop
     plugs:
       - unity7


### PR DESCRIPTION
Snapd actually allows directly running the application by using `_snap_name_` command when the _app_name_ is identical with the
_snap_name_.  This patch makes the necessary changes to support this feature.

Refer-to: The snapcraft syntax - Snaps are universal Linux packages
<https://docs.snapcraft.io/build-snaps/syntax#app-name>

```
If the app name matches the snap name, the app will be executed when the
name of the snap is called. Otherwise, the executable will have the snap
name and a dot prefixed to the app name.
```

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>