### PR TITLE
Connect to desktop* interfaces

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ apps:
   krop-app:
     command:        desktop-launch krop
     plugs:
+      - desktop
+      - desktop-legacy
       - unity7
       - home
       - removable-media


### PR DESCRIPTION
`desktop` interface is required to access basic graphical resources, `desktop-legacy` is required to support input method frameworks(like Fcitx) and a11y applications.  These two interfaces are not implicitly provided by the `unity` interface.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>